### PR TITLE
Fixing Dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/stretchr/testify/assert
-  - go get github.com/sirupsen/logrus
+  - go get github.com/Sirupsen/logrus
   - go get github.com/spf13/viper
   - go get github.com/tuvistavie/securerandom
   - go get gopkg.in/mattes/go-expand-tilde.v1

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,7 +8,7 @@
 			"Rev": "12f418cc7edc5a618a51407b7ac1f1f512139df3"
 		},
 		{
-			"ImportPath": "github.com/sirupsen/logrus",
+			"ImportPath": "github.com/Sirupsen/logrus",
 			"Comment": "v0.10.0-16-gcd7d1bb",
 			"Rev": "cd7d1bbe41066b6c1f19780f895901052150a575"
 		},

--- a/edgegrid.go
+++ b/edgegrid.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/go-ini/ini"
-	log "github.com/sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/tuvistavie/securerandom"
 	"gopkg.in/mattes/go-expand-tilde.v1"
 	"io/ioutil"


### PR DESCRIPTION
This is the correct name of repository.

Using lower case causes conflict of dependencies on build. 

`<file>:<line>:<col>: case-insensitive import collision: "github.com/<user>/<path> /vendor/github.com/Sirupsen/logrus" and "github.com/<user>/<path>/vendor/github.com/sirupsen/logrus"`

This way, the `vendor` will have `github.com/Sirupsen/logrus` and `github.com/sirupsen/logrus`.

ref: https://github.com/Sirupsen/logrus